### PR TITLE
 - add missing uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-plotly",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "main": "dist/library.js",
   "module": "dist/library.mjs",
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c",
-    "deplot": "bash deploy.sh",
+    "deploy": "bash deploy.sh",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs"
   },
@@ -42,6 +42,7 @@
     "vuepress": "^1.9.7"
   },
   "dependencies": {
-    "plotly.js-dist": "^2.12.1"
+    "plotly.js-dist": "^2.12.1",
+    "uuid": "^9.0.0"
   }
 }


### PR DESCRIPTION
When I used it as a dependency for a  Vue app the `uuid` package was missing.
This fixed it, but not sure it's the right thing bc  JS is not my main thing.

What do you think of this PR

Changes:
 - fix typo in package.json command
 - bump version
 - add missing uuid dependency