### PR TITLE
Added dynamic import, bundle choice & event listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,14 @@
     "vuepress": "^1.9.9"
   },
   "dependencies": {
-    "plotly.js-dist": "^2.24.2"
+    "plotly.js-dist": "^2.24.2",
+    "plotly.js-basic-dist-min": "^2.26.2",
+    "plotly.js-cartesian-dist-min": "^2.26.2",
+    "plotly.js-finance-dist-min": "^2.26.2",
+    "plotly.js-geo-dist-min": "^2.26.2",
+    "plotly.js-gl2d-dist-min": "^2.26.2",
+    "plotly.js-gl3d-dist-min": "^2.26.2",
+    "plotly.js-mapbox-dist-min": "^2.26.2",
+    "plotly.js-strict-dist-min": "^2.26.2",
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,40 @@
+const eventsName = [
+	"AfterExport",
+	"AfterPlot",
+	"Animated",
+	"AnimatingFrame",
+	"AnimationInterrupted",
+	"AutoSize",
+	"BeforeExport",
+	"ButtonClicked",
+	"Click",
+	"ClickAnnotation",
+	"Deselect",
+	"DoubleClick",
+	"Framework",
+	"Hover",
+	"LegendClick",
+	"LegendDoubleClick",
+	"Relayout",
+	"Restyle",
+	"Redraw",
+	"Selected",
+	"Selecting",
+	"SliderChange",
+	"SliderEnd",
+	"SliderStart",
+	"Transitioning",
+	"TransitionInterrupted",
+	"Unhover"
+];
+	
+const events = eventsName
+.map(evt => evt.toLocaleLowerCase())
+.map(eventName => ({
+	completeName: "plotly_" + eventName,
+	handler: context => (...args) => {			
+			context.$emit.apply(context, [eventName, ...args]);
+	}
+}));
+	
+export default events;


### PR DESCRIPTION
Added a property bundle to vue3-plotly : it can take values basic/cartesian/geo/gl3d/gl2d/mapbox/finance/strict like the different Plotly.js partial bundles https://github.com/plotly/plotly.js/blob/master/dist/README.md#plotlyjs-basic . It can make builds lighter. No value loads full Plotly.js

Added dynamic import so builds make a file for Plotly and website is lighter to load.

Added event listeners : now you can pass as property an action like @afterplot="graphDrawCallback". Event names are the same as Plotly.js